### PR TITLE
Get model running in TC 10

### DIFF
--- a/SourceCode/TimeManager.rsc
+++ b/SourceCode/TimeManager.rsc
@@ -104,7 +104,7 @@ Class "ABM.TimeManager"(opts)
         vT = Vector(self.NumberTimeSlots, "Long", {{"Sequence", 1, 1}})
 
         // Create empty matrix: Current limitation of 'CreateFromArrays': Cannot accept InMemory Matrix
-        obj = CreateObject("Matrix")
+        obj = CreateObject("Matrix", {Empty: TRUE})
         obj.SetMatrixOptions({Compressed: 0, 
                                 DataType: "Short",
                                 FileName: GetTempPath() + "TimeUse1.mtx",

--- a/SourceCode/TransitAssignment.rsc
+++ b/SourceCode/TransitAssignment.rsc
@@ -35,7 +35,7 @@ Macro "GenerateTransitOD" (Args)
         mODT.SetRowIndex("Rows")
         mODT.SetColIndex("Columns")
         if i = 1 then do
-            o = CreateObject("Matrix")
+            o = CreateObject("Matrix", {Empty: TRUE})
             mOut = o.CloneMatrixStructure({MatrixLabel: "TransitTrips", CloneSource: mODT.w_bus, MatrixFile: transitod, Matrices: cores })
             mo = CreateObject("Matrix", mOut)
         end

--- a/SourceCode/Utilities.rsc
+++ b/SourceCode/Utilities.rsc
@@ -13,7 +13,7 @@ Macro "Create Empty Matrix"(mSpec)
     vID = GetDataVector(vwTAZ + "|", "TAZID",)
     tazIDs = SortArray(v2a(vID))
 
-    obj = CreateObject("Matrix") 
+    obj = CreateObject("Matrix", {Empty: TRUE}) 
     obj.SetMatrixOptions({Compressed: 1, DataType: mSpec.DataType, MatrixLabel: mSpec.Label})
     obj.MatrixFileName = mSpec.OutputFile
     opts = {RowIDs: tazIDs, ColIDs: tazIDs, MatrixNames: mSpec.Cores, RowIndexName: "TAZ", ColIndexName: "TAZ"}

--- a/SourceCode/utils/utils.rsc
+++ b/SourceCode/utils/utils.rsc
@@ -2328,7 +2328,7 @@ Macro "Create Intra Cluster Matrix"(Args)
 
   outMtx = Args.[Output Folder] + "/skims/IntraCluster.mtx"
   // Create empty matrix
-  obj = CreateObject("Matrix") 
+  obj = CreateObject("Matrix", {Empty: TRUE}) 
   obj.SetMatrixOptions({Compressed: 1, DataType: "Short", FileName: outMtx, MatrixLabel: "IntraCluster"})
   opts.RowIds = v2a(vTAZ) 
   opts.ColIds = v2a(vTAZ)


### PR DESCRIPTION
TC 10 platform change required a few code changes. From this point on, the development version of the model (and any releases) will not run in TC 9 or older.