### PR TITLE
Get code working when MT districts are not defined

### DIFF
--- a/SourceCode/ABM_Utilities.rsc
+++ b/SourceCode/ABM_Utilities.rsc
@@ -575,6 +575,9 @@ Macro "Write ABM OD"(Args)
     mSkimObj = CreateObject("Matrix", Args.HighwaySkimAM)
     mSkimObj.SetIndex("TAZ")
     mcSkim = mSkimObj.Time
+
+    // Check if microtransit districts are defined
+    mtExists = RunMacro("MT Districts Exist?", Args)
     
     periods = {'AM', 'PM', 'OP'}
     for p in periods do
@@ -598,11 +601,13 @@ Macro "Write ABM OD"(Args)
         mObj.DropCores("other")
         mObj.DropCores("nonhhauto")
         // Add mt trips to carpool core. Instead of dropping the mt core,
-        // rename it. This will let planners easily see where MT trips are
+        // rename it. This will let modelers see where MT trips are
         // happening while avoiding confusion as to why mt isn't a class in
         // assignment.
-        mObj.carpool := nz(mObj.carpool) + nz(mObj.mt)
-        mObj.RenameCores({CurrentNames: {"mt"}, NewNames: {"mt_added2CP"}})
+        if mtExists then do
+            mObj.carpool := nz(mObj.carpool) + nz(mObj.mt)
+            mObj.RenameCores({CurrentNames: {"mt"}, NewNames: {"mt_added2CP"}})
+        end
         mObj = null
     end
     DestroyExpression(GetFieldFullSpec(vwTrips, odPeriod))

--- a/SourceCode/MandatoryModeChoice.rsc
+++ b/SourceCode/MandatoryModeChoice.rsc
@@ -545,7 +545,7 @@ Macro "Construct MC Spec"(Args, spec)
         Throw("No bus mode in mode choice utility for: " + type)
 
     // Now remove non essential cols from the transit utility
-    trUtil = RunMacro("Filter Transit Utility Spec", Args.(type + "ModeUtilityPT"), activeTransitModes)
+    trUtil = RunMacro("Filter Transit Utility Spec", Args.(type + "ModeUtilityPT"), activeTransitModes, Args)
     ret = RunMacro("Append Utility", AutoNMUtil, trUtil)
     finalUtil = ret.Utility
     finalAlts = ret.Alternatives
@@ -626,7 +626,7 @@ endMacro
 
 
 // Remove non active transit modes from the transit utility spec
-Macro "Filter Transit Utility Spec"(util, activeTransitModes)
+Macro "Filter Transit Utility Spec"(util, activeTransitModes, Args)
     commonCols = {"Description", "Expression", "Coefficient"}
     colNames = util.Map(do (f) Return(f[1]) end)
 
@@ -636,6 +636,11 @@ Macro "Filter Transit Utility Spec"(util, activeTransitModes)
         if commonCols.Position(col) > 0 then // Retain the common cols
             trUtil.(col) = CopyArray(util.(col))
         
+        // Skip microtransit modes if no districts are defined
+        mtPresent = RunMacro("MT Districts Exist?", Args)
+        if !mtPresent and Left(Lower(col), 3) = "mt_" then
+            continue
+
         // Check if col is contained in the active transit modes
         retainCol = RunMacro("Is value in array", activeTransitModes, col)
         if retainCol then do


### PR DESCRIPTION
These changes fix crashes in the model when MT districts were disabled.